### PR TITLE
Fixes for disabling gizmos

### DIFF
--- a/1.6/Source/KeyzAllowUtilities/Designator_FinishOff.cs
+++ b/1.6/Source/KeyzAllowUtilities/Designator_FinishOff.cs
@@ -16,6 +16,8 @@ public class Designator_FinishOff : Designator
         set => disabled = value;
     }
 
+    public override bool Visible => !KeyzAllowUtilitiesMod.settings.DisableFinishOff;
+
     protected override DesignationDef Designation => KeyzAllowUtilitesDefOf.KAU_FinishOffDesignation;
 
     public override DrawStyleCategoryDef DrawStyleCategory => DrawStyleCategoryDefOf.FilledRectangle;

--- a/1.6/Source/KeyzAllowUtilities/Designator_StripMine.cs
+++ b/1.6/Source/KeyzAllowUtilities/Designator_StripMine.cs
@@ -19,6 +19,8 @@ public class Designator_StripMine : Designator_Mine
         set => disabled = value;
     }
 
+    public override bool Visible => !KeyzAllowUtilitiesMod.settings.DisableStripMine;
+
     Texture2D Diagram = ContentFinder<Texture2D>.Get("UI/KAU_StripMineDiagram");
 
     public Designator_StripMine()

--- a/1.6/Source/KeyzAllowUtilities/Designator_StripMine.cs
+++ b/1.6/Source/KeyzAllowUtilities/Designator_StripMine.cs
@@ -13,6 +13,12 @@ public class Designator_StripMine : Designator_Mine
     public static int SpacingX = 1;
     public static int SpacingZ = 1;
 
+    public override bool Disabled
+    {
+        get => disabled || KeyzAllowUtilitiesMod.settings.DisableStripMine;
+        set => disabled = value;
+    }
+
     Texture2D Diagram = ContentFinder<Texture2D>.Get("UI/KAU_StripMineDiagram");
 
     public Designator_StripMine()

--- a/1.6/Source/KeyzAllowUtilities/Settings.cs
+++ b/1.6/Source/KeyzAllowUtilities/Settings.cs
@@ -8,6 +8,7 @@ public class Settings : ModSettings
     public int MaxSelect = 300;
     public bool DisableHaulUrgently = false;
     public bool DisableFinishOff = false;
+    public bool DisableStripMine = false;
     public bool AllowFinishOffOnFriendly = false;
     public bool DisableAllowShortcuts = false;
     public bool DisableAllShortcuts = false;
@@ -26,6 +27,9 @@ public class Settings : ModSettings
         options.Gap();
 
         options.CheckboxLabeled("KAU_ToggleFinishOff".Translate(), ref DisableFinishOff);
+        options.Gap();
+
+        options.CheckboxLabeled("KAU_ToggleStripMine".Translate(), ref DisableStripMine);
         options.Gap();
 
         options.CheckboxLabeled("KAU_ToggleAllowFinishOffOnFriendly".Translate(), ref AllowFinishOffOnFriendly);
@@ -73,6 +77,7 @@ public class Settings : ModSettings
         Scribe_Values.Look(ref MaxSelect, "MaxSelect", 300);
         Scribe_Values.Look(ref DisableHaulUrgently, "DisableHaulUrgently", false);
         Scribe_Values.Look(ref DisableFinishOff, "DisableFinishOff", false);
+        Scribe_Values.Look(ref DisableStripMine, "DisableStripMine", false);
         Scribe_Values.Look(ref AllowFinishOffOnFriendly, "AllowFinishOffOnFriendly", false);
         Scribe_Values.Look(ref DisableAllowShortcuts, "DisableAllowShortcuts", false);
         Scribe_Values.Look(ref DisableAllShortcuts, "DisableAllShortcuts", false);

--- a/Common/Languages/English/Keyed/KeyzAllowUtilities_Misc_UI.xml
+++ b/Common/Languages/English/Keyed/KeyzAllowUtilities_Misc_UI.xml
@@ -49,6 +49,7 @@
 
     <KAU_ToggleHaulUrgently>Disable Haul Urgently</KAU_ToggleHaulUrgently>
     <KAU_ToggleFinishOff>Disable Finish Off</KAU_ToggleFinishOff>
+    <KAU_ToggleStripMine>Disable Strip Mine</KAU_ToggleStripMine>
     <KAU_ToggleAllowFinishOffOnFriendly>Allow finish off on friendly pawns</KAU_ToggleAllowFinishOffOnFriendly>
 
     <KAU_ToggleDisableAllowShortcuts>Disable Allow/Forbid hotkeys</KAU_ToggleDisableAllowShortcuts>


### PR DESCRIPTION
Add option to disable strip mine gizmo.

Fix finish-off and strip-mine to not show in Architect->Orders (for some reason that I fail to see they need extra code, unlike haul-urgently).
