### PR TITLE
Remember filter in a single selection session

### DIFF
--- a/1.6/Source/KeyzAllowUtilities/Designator_SelectSimilar.cs
+++ b/1.6/Source/KeyzAllowUtilities/Designator_SelectSimilar.cs
@@ -10,6 +10,7 @@ namespace KeyzAllowUtilities;
 [StaticConstructorOnStartup]
 public class Designator_SelectSimilar : Designator
 {
+    private readonly List<Thing> similarTo = [];
     private Func<Thing, bool> filter = null;
     private Func<Thing, bool> filterWithStuff = null;
 
@@ -21,8 +22,6 @@ public class Designator_SelectSimilar : Designator
 
     public override bool Visible => !KeyzAllowUtilitiesMod.settings.DisableSelection;
     public override DrawStyleCategoryDef DrawStyleCategory => DrawStyleCategoryDefOf.FilledRectangle;
-
-    public static readonly Material DragHighlightThingMat = MaterialPool.MatFrom("UI/KUA_HaulHighlight", ShaderDatabase.MetaOverlay);
 
     public Designator_SelectSimilar()
     {
@@ -38,18 +37,19 @@ public class Designator_SelectSimilar : Designator
 
     private Func<Thing, bool> GetFilter()
     {
-        if (Event.current?.shift ?? false)
+        // `similarTo` will only be non-empty between `Selected()` and `Deselected()` calls. So this emptiness check
+        // ensures the cached filter being consistent with the `similarTo`.
+        if (similarTo.Empty())
         {
-            filterWithStuff ??= FilterUtils.MakeFilter(Find.Selector.SelectedObjects.OfType<Thing>(), false);
-
-            return filterWithStuff;
+            return _ => false;
         }
-        else
-        {
-            filter ??= FilterUtils.MakeFilter(Find.Selector.SelectedObjects.OfType<Thing>(), true);
 
-            return filter;
-        }
+        bool ignoreStuff = Event.current?.shift ?? false;
+        ref Func<Thing, bool> selectedFilter = ref (ignoreStuff ? ref filter : ref filterWithStuff);
+
+        selectedFilter ??= FilterUtils.MakeFilter(similarTo, checkStuff: !ignoreStuff);
+
+        return selectedFilter;
     }
 
     public IEnumerable<Thing> SelectableThingsInCell(IntVec3 c)
@@ -90,6 +90,18 @@ public class Designator_SelectSimilar : Designator
 
     public override void SelectedUpdate() => GenUI.RenderMouseoverBracket();
 
+    public override void Selected()
+    {
+        similarTo.AddRange(Find.Selector.SelectedObjects.OfType<Thing>());
+    }
+
+    public override void Deselected()
+    {
+        similarTo.Clear();
+        filter = null;
+        filterWithStuff = null;
+    }
+
     private static HashSet<Vector2> drawnPos = new();
 
     public override void RenderHighlight(List<IntVec3> dragCells)
@@ -103,24 +115,10 @@ public class Designator_SelectSimilar : Designator
                 {
                     Vector3 drawPos = new(drawPosHeld.x, AltitudeLayer.MetaOverlays.AltitudeFor(), drawPosHeld.z);
 
-                    Graphics.DrawMesh(MeshPool.plane10, drawPos, Quaternion.identity, DragHighlightThingMat, 0);
+                    Graphics.DrawMesh(MeshPool.plane10, drawPos, Quaternion.identity, DesignatorUtility.DragHighlightThingMat, 0);
                 }
             }
         }
         drawnPos.Clear();
-    }
-
-    protected override void FinalizeDesignationSucceeded()
-    {
-        filter = null;
-        filterWithStuff = null;
-        base.FinalizeDesignationSucceeded();
-    }
-
-    protected override void FinalizeDesignationFailed()
-    {
-        filter = null;
-        filterWithStuff = null;
-        base.FinalizeDesignationFailed();
     }
 }

--- a/1.6/Source/KeyzAllowUtilities/KeyHandler.cs
+++ b/1.6/Source/KeyzAllowUtilities/KeyHandler.cs
@@ -62,14 +62,14 @@ public class KeyHandler(Map map) : MapComponent(map)
             Event.current.Use();
         }else if (!KeyzAllowUtilitiesMod.settings.DisableFinishOff && KeyzAllowUtilitesDefOf.KAU_FinishOff.KeyDownEvent)
         {
-            if (selectSimilar != null)
+            if (finishOff != null)
             {
                 Find.DesignatorManager.Select(finishOff);
             }
             Event.current.Use();
         }else if (!KeyzAllowUtilitiesMod.settings.DisableHaulUrgently && KeyzAllowUtilitesDefOf.KAU_HaulUrgentlySelection.KeyDownEvent)
         {
-            if (selectSimilar != null)
+            if (haulUrgently != null)
             {
                 Find.DesignatorManager.Select(haulUrgently);
             }


### PR DESCRIPTION
This PR will keep the filters the same across a single selection session (from `Selected()` call to `Deselected()` call). This will fix an issue that:

1. Use select similar tool on blue prints.
2. Use the <kbd>C</kbd> key to cancel all selected blue prints.
3. Try to select new blue prints, which currently fails and will be able to work with this PR.

I also noticed two typos in `1.6/Source/KeyzAllowUtilities/KeyHandler.cs`, which will also be fixed by this PR.

I also change the highlighting material to the built-in `DesignatorUtility.DragHighlightThingMat` material, this is needed to fix a strange “Tried to get a material from a different thread” error introduced by this PR. The error was caused by the static constructor of `Designator_SelectSimilar` somehow gets called from a non-main thread. But if I remove the `Selected` and `Deselected` methods, the static constructor get called on the main thread, so the error goes away. I am unable to figure out why it behaves like this, but I can think of three ways to workaround it:

- Use `Lazy<Material>` type for `DragHighlightThingMat`, so it will only be initialized on use.
- Put `DragHighlightThingMat` in another type so that the static constructor will not call its initializer.
- Using a built-in material to avoid calling the initializer.

Currently, I am using the built-in material workaround, which I think matches the vanilla style better, and potentially results in some performance benefit due to reuse of textures.