### PR TITLE
Two small fixes on designating “HaulUrgently” on a thing that is designated “Haul”

### DIFF
--- a/1.6/Source/KeyzAllowUtilities/Designator_HaulUrgently.cs
+++ b/1.6/Source/KeyzAllowUtilities/Designator_HaulUrgently.cs
@@ -52,7 +52,7 @@ public class Designator_HaulUrgently : Designator
 
     public override void DesignateSingleCell(IntVec3 c)
     {
-        Thing haulable = GetFirstUgentHaulable(c,Map);
+        Thing haulable = GetFirstUgentHaulable(c, Map);
         if (haulable != null)
             DesignateThing(haulable);
     }
@@ -70,8 +70,15 @@ public class Designator_HaulUrgently : Designator
 
     public override void DesignateThing(Thing t)
     {
-        Map.designationManager.AddDesignation(new Designation((LocalTargetInfo) t, Designation));
-        Map.designationManager.AddDesignation(new Designation((LocalTargetInfo) t, DesignationDefOf.Haul));
+        DesignationManager designationManager = Map.designationManager;
+
+        designationManager.AddDesignation(new Designation((LocalTargetInfo) t, Designation));
+
+        if (designationManager.DesignationOn(t, DesignationDefOf.Haul) == null)
+        {
+            designationManager.AddDesignation(new Designation((LocalTargetInfo) t, DesignationDefOf.Haul));
+        }
+
         t.SetForbidden(false, false);
     }
 

--- a/1.6/Source/KeyzAllowUtilities/HarmonyPatches/Thing_Patches.cs
+++ b/1.6/Source/KeyzAllowUtilities/HarmonyPatches/Thing_Patches.cs
@@ -138,10 +138,9 @@ public static class Thing_Patches
                         }
                         if (Event.current == null || Event.current.button == 0)
                         {
-                            if (!__instance.IsInValidBestStorage() && !currentMap.designationManager.HasMapDesignationOn(__instance))
+                            if (!__instance.IsInValidBestStorage() && currentMap.designationManager.DesignationOn(__instance, KeyzAllowUtilitesDefOf.KAU_HaulUrgentlyDesignation) == null)
                             {
-                                currentMap.designationManager.AddDesignation(new Designation(__instance, KeyzAllowUtilitesDefOf.KAU_HaulUrgentlyDesignation));
-                                currentMap.designationManager.AddDesignation(new Designation(__instance, DesignationDefOf.Haul));
+                                haulUrgently.DesignateThing(__instance);
                             }
                         }
                         else


### PR DESCRIPTION
This PR attempts to fix the following issues:

- When designating “HaulUrgently” on a thing that is designated “Haul” (such as a stone chunk), a “Tried to double-add designation on Thing” error message is printed.
- You can designate “HaulUrgently” on a thing that is designated “Haul” using the corresponding designator, but not the gizmo.